### PR TITLE
chore: configure base path and docs output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,8 @@ export default defineConfig(({ mode }) => {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
+      base: '/ai-studio-tetris/',
+      build: { outDir: 'docs' },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- set Vite base path to `/ai-studio-tetris/`
- output build artifacts to `docs/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b144b24d94832b84cae83df5554ade