### PR TITLE
chore: add gh-pages deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "npm run build && gh-pages -d docs"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "gh-pages": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add gh-pages as a dev dependency
- provide a `deploy` script for building and publishing docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b14514e1ec832ba2c8013d10520fc5