### PR TITLE
Remove gh-pages dependency for deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && gh-pages -d docs"
+    "deploy": "npm run build && git subtree push --prefix docs origin gh-pages"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -16,7 +16,6 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0",
-    "gh-pages": "^6.0.0"
+    "vite": "^6.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && git subtree push --prefix docs origin gh-pages"
+    "deploy": "npm run build && git subtree push --prefix docs origin gh-pages --force"
   },
   "dependencies": {
     "react": "^19.1.1",


### PR DESCRIPTION
## Summary
- deploy script now uses `git subtree push` instead of the `gh-pages` package
- drop unused `gh-pages` dev dependency to keep lockfile in sync

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b23b13af90832ba63b347f548c0db4